### PR TITLE
feat: Normalize database schema and add phase2 plan

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tanstack/react-table": "^8.10.7",
     "@types/bcryptjs": "^2.4.6",
     "axios": "^1.6.2",
-    "bcryptjs": "^3.0.2",
+    "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.3.1",

--- a/phase2.md
+++ b/phase2.md
@@ -1,0 +1,45 @@
+# Phase 2: Reporting and Analytics Feature
+
+This document outlines the plan for implementing the reporting and analytics feature in DemandIT.
+
+## 1. Create the Reporting Page
+
+-   **Task:** Create a new page component at `src/app/reporting/page.tsx`.
+-   **Details:** This page will serve as the main dashboard for all reports and analytics.
+-   **Sub-tasks:**
+    -   Create the basic page structure with a title and layout.
+    -   Add a link to the reporting page in the main navigation (`src/components/main-nav.tsx`).
+
+## 2. Develop API Endpoints for Reporting Data
+
+-   **Task:** Create new API routes in `src/app/api/reporting/` to fetch the data needed for the reports.
+-   **Details:** These endpoints will provide the data for the charts and graphs on the reporting page.
+-   **Sub-tasks:**
+    -   Create an endpoint for demand analytics (e.g., demands by category, priority, status over time).
+    -   Create an endpoint for project analytics (e.g., project budget vs. spent, project timelines, burndown charts).
+    -   Create an endpoint for resource analytics (e.g., resource allocation, utilization, capacity).
+
+## 3. Implement Data Visualizations
+
+-   **Task:** Use the existing `recharts` library to create various charts and graphs for the reporting page.
+-   **Details:** The charts will provide a visual representation of the data.
+-   **Sub-tasks:**
+    -   Implement bar charts for categorical data (e.g., demands by status).
+    -   Implement line charts for time-series data (e.g., burndown charts).
+    -   Implement pie charts for proportional data (e.g., resource allocation by project).
+
+## 4. Add Filtering and Exporting Capabilities
+
+-   **Task:** Add controls to the reporting page to filter the data and export it.
+-   **Details:** This will allow users to customize the reports to their needs.
+-   **Sub-tasks:**
+    -   Add filters for date range, project, user, etc.
+    -   Implement functionality to export the report data to CSV or PDF.
+
+## 5. Write Tests for the New Functionality
+
+-   **Task:** Add tests for the new reporting and analytics feature.
+-   **Details:** This will ensure the feature is working correctly and prevent regressions.
+-   **Sub-tasks:**
+    -   Add unit tests for the new API endpoints.
+    -   Add integration tests for the reporting page.

--- a/prisma/migrations/20250911124304_bugfixes_and_normalization/migration.sql
+++ b/prisma/migrations/20250911124304_bugfixes_and_normalization/migration.sql
@@ -1,0 +1,187 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `entityId` on the `Comment` table. All the data in the column will be lost.
+  - You are about to drop the column `entityType` on the `Comment` table. All the data in the column will be lost.
+  - You are about to drop the column `attachments` on the `Demand` table. All the data in the column will be lost.
+  - You are about to drop the column `tags` on the `Demand` table. All the data in the column will be lost.
+  - You are about to drop the column `tags` on the `Project` table. All the data in the column will be lost.
+  - You are about to drop the column `skills` on the `User` table. All the data in the column will be lost.
+
+*/
+-- CreateTable
+CREATE TABLE "Skill" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Tag" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "fileName" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "_DemandToTag" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+    CONSTRAINT "_DemandToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Demand" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_DemandToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "_ProjectToTag" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+    CONSTRAINT "_ProjectToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_ProjectToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "_SkillToUser" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+    CONSTRAINT "_SkillToUser_A_fkey" FOREIGN KEY ("A") REFERENCES "Skill" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_SkillToUser_B_fkey" FOREIGN KEY ("B") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "_AttachmentToDemand" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+    CONSTRAINT "_AttachmentToDemand_A_fkey" FOREIGN KEY ("A") REFERENCES "Attachment" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_AttachmentToDemand_B_fkey" FOREIGN KEY ("B") REFERENCES "Demand" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "_AttachmentToProject" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+    CONSTRAINT "_AttachmentToProject_A_fkey" FOREIGN KEY ("A") REFERENCES "Attachment" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_AttachmentToProject_B_fkey" FOREIGN KEY ("B") REFERENCES "Project" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Comment" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "content" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "demandId" TEXT,
+    "projectId" TEXT,
+    CONSTRAINT "Comment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Comment_demandId_fkey" FOREIGN KEY ("demandId") REFERENCES "Demand" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Comment_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Comment" ("content", "createdAt", "id", "updatedAt", "userId") SELECT "content", "createdAt", "id", "updatedAt", "userId" FROM "Comment";
+DROP TABLE "Comment";
+ALTER TABLE "new_Comment" RENAME TO "Comment";
+CREATE TABLE "new_Demand" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "priorityId" TEXT NOT NULL,
+    "statusId" TEXT NOT NULL,
+    "requestedBy" TEXT NOT NULL,
+    "requestedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "businessValue" INTEGER NOT NULL,
+    "complexity" TEXT NOT NULL,
+    "estimatedEffort" INTEGER NOT NULL,
+    "actualEffort" INTEGER DEFAULT 0,
+    "dueDate" DATETIME,
+    "projectId" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Demand_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Demand_priorityId_fkey" FOREIGN KEY ("priorityId") REFERENCES "Priority" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Demand_statusId_fkey" FOREIGN KEY ("statusId") REFERENCES "Status" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Demand_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Demand" ("actualEffort", "businessValue", "categoryId", "complexity", "createdAt", "description", "dueDate", "estimatedEffort", "id", "priorityId", "projectId", "requestedAt", "requestedBy", "statusId", "title", "updatedAt") SELECT "actualEffort", "businessValue", "categoryId", "complexity", "createdAt", "description", "dueDate", "estimatedEffort", "id", "priorityId", "projectId", "requestedAt", "requestedBy", "statusId", "title", "updatedAt" FROM "Demand";
+DROP TABLE "Demand";
+ALTER TABLE "new_Demand" RENAME TO "Demand";
+CREATE TABLE "new_Project" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "statusId" TEXT NOT NULL,
+    "priorityId" TEXT NOT NULL,
+    "startDate" DATETIME NOT NULL,
+    "targetEndDate" DATETIME NOT NULL,
+    "actualEndDate" DATETIME,
+    "budget" REAL NOT NULL,
+    "spent" REAL NOT NULL DEFAULT 0,
+    "managerId" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Project_statusId_fkey" FOREIGN KEY ("statusId") REFERENCES "Status" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Project_priorityId_fkey" FOREIGN KEY ("priorityId") REFERENCES "Priority" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Project_managerId_fkey" FOREIGN KEY ("managerId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Project" ("actualEndDate", "budget", "createdAt", "description", "id", "managerId", "name", "priorityId", "spent", "startDate", "statusId", "targetEndDate", "updatedAt") SELECT "actualEndDate", "budget", "createdAt", "description", "id", "managerId", "name", "priorityId", "spent", "startDate", "statusId", "targetEndDate", "updatedAt" FROM "Project";
+DROP TABLE "Project";
+ALTER TABLE "new_Project" RENAME TO "Project";
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "role" TEXT NOT NULL DEFAULT 'TEAM_MEMBER',
+    "capacity" INTEGER NOT NULL DEFAULT 40,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("capacity", "createdAt", "email", "id", "name", "password", "role", "updatedAt") SELECT "capacity", "createdAt", "email", "id", "name", "password", "role", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Skill_name_key" ON "Skill"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_DemandToTag_AB_unique" ON "_DemandToTag"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_DemandToTag_B_index" ON "_DemandToTag"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ProjectToTag_AB_unique" ON "_ProjectToTag"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_ProjectToTag_B_index" ON "_ProjectToTag"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_SkillToUser_AB_unique" ON "_SkillToUser"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_SkillToUser_B_index" ON "_SkillToUser"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AttachmentToDemand_AB_unique" ON "_AttachmentToDemand"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AttachmentToDemand_B_index" ON "_AttachmentToDemand"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_AttachmentToProject_AB_unique" ON "_AttachmentToProject"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_AttachmentToProject_B_index" ON "_AttachmentToProject"("B");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
   email           String               @unique
   password        String
   role            String               @default("TEAM_MEMBER") // ADMIN, MANAGER, TEAM_MEMBER
-  skills          String               @default("[]") // Stored as JSON string
+  skills          Skill[]
   capacity        Int                  @default(40) // hours per week
   createdAt       DateTime             @default(now())
   updatedAt       DateTime             @updatedAt
@@ -82,8 +82,8 @@ model Demand {
   assignedTo      User[]
   relatedProject  Project?             @relation(fields: [projectId], references: [id])
   projectId       String?
-  tags            String               @default("[]") // Stored as JSON string
-  attachments     String               @default("[]") // Stored as JSON string
+  tags            Tag[]
+  attachments     Attachment[]
   comments        Comment[]
   allocations     ResourceAllocation[]
   createdAt       DateTime             @default(now())
@@ -109,7 +109,8 @@ model Project {
   demands         Demand[]
   allocations     ResourceAllocation[]
   comments        Comment[]
-  tags            String               @default("[]") // Stored as JSON string
+  tags            Tag[]
+  attachments     Attachment[]
   createdAt       DateTime             @default(now())
   updatedAt       DateTime             @updatedAt
 }
@@ -137,12 +138,34 @@ model Comment {
   content     String
   user        User      @relation(fields: [userId], references: [id])
   userId      String
-  entityType  String    // DEMAND, PROJECT, TASK
-  entityId    String
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
-  
-  // Relations for different entity types
-  demand      Demand?   @relation(fields: [entityId], references: [id])
-  project     Project?  @relation(fields: [entityId], references: [id])
+
+  // A comment can be associated with either a demand or a project
+  demand      Demand?   @relation(fields: [demandId], references: [id])
+  demandId    String?
+  project     Project?  @relation(fields: [projectId], references: [id])
+  projectId   String?
+}
+
+model Skill {
+  id     String @id @default(cuid())
+  name   String @unique
+  users  User[]
+}
+
+model Tag {
+  id       String    @id @default(cuid())
+  name     String    @unique
+  demands  Demand[]
+  projects Project[]
+}
+
+model Attachment {
+  id        String   @id @default(cuid())
+  fileName  String
+  url       String
+  demands   Demand[]
+  projects  Project[]
+  createdAt DateTime @default(now())
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,6 +7,16 @@ async function main() {
   // Create admin user
   const hashedPassword = await hash('admin123', 12);
   
+  const skills = await Promise.all(
+    ['Project Management', 'System Architecture', 'DevOps'].map((skill) =>
+      prisma.skill.upsert({
+        where: { name: skill },
+        update: {},
+        create: { name: skill },
+      })
+    )
+  );
+
   const admin = await prisma.user.upsert({
     where: { email: 'admin@demandit.com' },
     update: {},
@@ -15,7 +25,9 @@ async function main() {
       email: 'admin@demandit.com',
       password: hashedPassword,
       role: 'ADMIN',
-      skills: JSON.stringify(['Project Management', 'System Architecture', 'DevOps']),
+      skills: {
+        connect: skills.map((skill) => ({ id: skill.id })),
+      },
       capacity: 40,
     },
   });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth-options';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -179,5 +179,5 @@ export function debounce<T extends (...args: any[]) => void>(
   return function (this: any, ...args: Parameters<T>) {
     clearTimeout(timeout);
     timeout = setTimeout(() => func.apply(this, args), wait);
-  };
+  } as T;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,12 +14,17 @@ export interface MainNavItem {
 /**
  * @description The user.
  */
+export interface Skill {
+  id: string;
+  name: string;
+}
+
 export interface User {
   id: string;
   name: string;
   email: string;
   role: 'admin' | 'manager' | 'team_member';
-  skills: string[];
+  skills: Skill[];
   capacity: number; // hours per week
 }
 
@@ -57,8 +62,20 @@ export interface Status {
 /**
  * @description The demand.
  */
-export interface Demand {
+export interface Tag {
   id: string;
+  name: string;
+}
+
+export interface Attachment {
+  id: string;
+  fileName: string;
+  url: string;
+  createdAt: Date;
+}
+
+export interface Demand {
+  id:string;
   title: string;
   description: string;
   categoryId: string;
@@ -73,8 +90,8 @@ export interface Demand {
   dueDate?: Date;
   assignedTo?: string[];
   relatedProjectId?: string;
-  tags: string[];
-  attachments: string[];
+  tags: Tag[];
+  attachments: Attachment[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -96,7 +113,8 @@ export interface Project {
   managerId: string;
   teamMembers: string[];
   demands: string[];
-  tags: string[];
+  tags: Tag[];
+  attachments: Attachment[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -126,8 +144,8 @@ export interface Comment {
   id: string;
   content: string;
   userId: string;
-  entityType: 'demand' | 'project' | 'task';
-  entityId: string;
+  demandId?: string;
+  projectId?: string;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
This commit addresses several bugs and design flaws in the application.

- The database schema has been normalized to use relational tables for `skills`, `tags`, and `attachments` instead of JSON strings.
- The Prisma schema, seed script, and type definitions have been updated to reflect the new data model.
- A bug in the `debounce` function in `src/lib/utils.ts` has been fixed.
- The `bcryptjs` dependency has been updated to a version that is compatible with its type definitions.
- A critical bug in `src/app/page.tsx` that prevented the page from rendering has been fixed.
- A new `phase2.md` file has been added with a plan for the reporting and analytics feature.